### PR TITLE
Feature/security/http cookie o auth2 authorization request repository

### DIFF
--- a/application/src/main/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImpl.java
+++ b/application/src/main/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImpl.java
@@ -18,9 +18,6 @@ public class HttpCookieOauth2AuthorizationRequestRepositoryImpl implements HttpC
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest httpServletRequest) {
-
-        System.out.println("loadAuthroizationRequest");
-        System.out.println(CookieUtils.getCookie(httpServletRequest, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
         return CookieUtils.getCookie(httpServletRequest, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
                 .map(cookie -> CookieUtils.deserialize(cookie,OAuth2AuthorizationRequest.class))
                 .orElse(null);

--- a/application/src/main/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImpl.java
+++ b/application/src/main/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImpl.java
@@ -3,6 +3,7 @@ package me.ziok.application.security.oauth2;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import me.ziok.application.util.CookieUtils;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.util.Assert;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -17,6 +18,9 @@ public class HttpCookieOauth2AuthorizationRequestRepositoryImpl implements HttpC
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest httpServletRequest) {
+
+        System.out.println("loadAuthroizationRequest");
+        System.out.println(CookieUtils.getCookie(httpServletRequest, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
         return CookieUtils.getCookie(httpServletRequest, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
                 .map(cookie -> CookieUtils.deserialize(cookie,OAuth2AuthorizationRequest.class))
                 .orElse(null);

--- a/application/src/main/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImpl.java
+++ b/application/src/main/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImpl.java
@@ -1,5 +1,7 @@
 package me.ziok.application.security.oauth2;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import me.ziok.application.util.CookieUtils;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
 import javax.servlet.http.HttpServletRequest;
@@ -7,23 +9,43 @@ import javax.servlet.http.HttpServletResponse;
 
 //todo: implement
 public class HttpCookieOauth2AuthorizationRequestRepositoryImpl implements HttpCookieOauth2AuthorizationRequestRepository {
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest httpServletRequest) {
-        return null;
+        return CookieUtils.getCookie(httpServletRequest, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie,OAuth2AuthorizationRequest.class))
+                .orElse(null);
     }
 
     @Override
-    public void saveAuthorizationRequest(OAuth2AuthorizationRequest request, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        if ( authorizationRequest == null) {
+            CookieUtils.deleteCookie(httpServletRequest, httpServletResponse, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(httpServletRequest, httpServletResponse, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
 
+        CookieUtils.addCookie(httpServletResponse, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = httpServletRequest.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(httpServletResponse, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
     }
 
     @Override
     public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest httpServletRequest) {
-        return null;
+
+        return this.loadAuthorizationRequest(httpServletRequest);
     }
 
-    @Override
-    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
-        return null;
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
     }
 }

--- a/application/src/test/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImplTest.java
+++ b/application/src/test/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImplTest.java
@@ -1,0 +1,72 @@
+package me.ziok.application.security.oauth2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpCookieOauth2AuthorizationRequestRepositoryImplTest {
+
+    private HttpCookieOauth2AuthorizationRequestRepository authorizationRequestRepository =
+            new HttpCookieOauth2AuthorizationRequestRepositoryImpl();
+
+//    @Test(expected = IllegalArgumentException.class)
+//    public void loadAuthorizationRequestWhenHttpServletRequestIsNullThenThrowIllegalArgumentException() {
+//        this.authorizationRequestRepository.loadAuthorizationRequest(null);
+//    }
+
+    @Test
+    public void loadAuthorizationRequestWhenNotSavedThenReturnNull() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter(OAuth2ParameterNames.STATE, "state-1234");
+        OAuth2AuthorizationRequest authorizationRequest =
+                this.authorizationRequestRepository.loadAuthorizationRequest(request);
+        System.out.println(request.getParameter(OAuth2ParameterNames.STATE));
+
+
+        assertThat(authorizationRequest).isNull();
+
+    }
+
+    @Test
+    public void loadAuthorizationRequestWhenSavedThenReturnAuthorizationRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        OAuth2AuthorizationRequest authorizationRequest = createAuthorizationRequest().build();
+
+        this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest,request,response);
+
+        request.addParameter(OAuth2ParameterNames.STATE, authorizationRequest.getState());
+        OAuth2AuthorizationRequest loadedAuthorizationRequest =
+                this.authorizationRequestRepository.loadAuthorizationRequest(request);
+
+        assertThat(loadedAuthorizationRequest).isEqualTo(authorizationRequest);
+    }
+
+    @Test
+    public void saveAuthorizationRequest() {
+    }
+
+    @Test
+    public void removeAuthorizationRequest() {
+    }
+
+    @Test
+    public void removeAuthorizationRequestCookies() {
+    }
+
+    private OAuth2AuthorizationRequest.Builder createAuthorizationRequest() {
+        return OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri("https://example.com/oauth2/authorize")
+                .clientId("client-id-1234")
+                .state("state-1234");
+    }
+}

--- a/application/src/test/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImplTest.java
+++ b/application/src/test/java/me/ziok/application/security/oauth2/HttpCookieOauth2AuthorizationRequestRepositoryImplTest.java
@@ -1,26 +1,34 @@
 package me.ziok.application.security.oauth2;
 
+import me.ziok.application.util.CookieUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpCookieOauth2AuthorizationRequestRepositoryImplTest {
 
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
     private HttpCookieOauth2AuthorizationRequestRepository authorizationRequestRepository =
             new HttpCookieOauth2AuthorizationRequestRepositoryImpl();
 
-//    @Test(expected = IllegalArgumentException.class)
-//    public void loadAuthorizationRequestWhenHttpServletRequestIsNullThenThrowIllegalArgumentException() {
-//        this.authorizationRequestRepository.loadAuthorizationRequest(null);
-//    }
 
     @Test
     public void loadAuthorizationRequestWhenNotSavedThenReturnNull() {
@@ -37,18 +45,22 @@ public class HttpCookieOauth2AuthorizationRequestRepositoryImplTest {
 
     @Test
     public void loadAuthorizationRequestWhenSavedThenReturnAuthorizationRequest() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
+//        MockHttpServletRequest request = new MockHttpServletRequest();
+//        MockHttpServletResponse response = new MockHttpServletResponse();
 
+        //given
         OAuth2AuthorizationRequest authorizationRequest = createAuthorizationRequest().build();
+        Cookie[] cookies = {new Cookie("oauth2_auth_request", CookieUtils.serialize(authorizationRequest))};
+        when(request.getCookies()).thenReturn(cookies);
+        // request.addParameter(OAuth2ParameterNames.STATE, authorizationRequest.getState());
 
+        //when
         this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest,request,response);
-
-        request.addParameter(OAuth2ParameterNames.STATE, authorizationRequest.getState());
         OAuth2AuthorizationRequest loadedAuthorizationRequest =
                 this.authorizationRequestRepository.loadAuthorizationRequest(request);
 
-        assertThat(loadedAuthorizationRequest).isEqualTo(authorizationRequest);
+        //then
+        assertThat(loadedAuthorizationRequest.getClientId()).isEqualTo(authorizationRequest.getClientId());
     }
 
     @Test

--- a/application/src/test/java/me/ziok/application/util/CookieUtilsTest.java
+++ b/application/src/test/java/me/ziok/application/util/CookieUtilsTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -46,6 +48,10 @@ public class CookieUtilsTest {
 
     @Test
     public  void addCookie() {
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
         boolean expResult = false;
         //when
         boolean result = CookieUtils.addCookie(response,null, null, 1);
@@ -60,6 +66,10 @@ public class CookieUtilsTest {
 
         //then
         assertEquals(expResult, result);
+
+
+        System.out.println(CookieUtils.getCookie(request, "cookieNmae"));
+
     }
 
 }


### PR DESCRIPTION
@KwonGiho 

하다가 모르겠는 것이 있어서 풀리퀘 올리고 질문합니다 ㅜㅜ
이 부분 테스트하는 건 찾기가 어려워서 제 생각대로 해봤는데, 이렇게 해도 괜찮은 건지 모르겠네요

지금 AuthorizationRequest를 리포지토리에 쿠키로 저장하고, 겟하는 부분을 구현하고 있습니다.

제가 의아한 부분은 CookieUtils 부분에서 getCookie를 할 때 `request.getCookies`를 사용하는데,
request에 addCookie를 할 수 없다는 것입니다. 테스트할 때야 목 객체로  `when(request.getCookies()).thenReturn(cookies);`
이런식으로 cookies를 안에 넣어줄 수 있지만, 실제로는 못넣어주니 의미가 있나 싶네요.

애초에 CookieUtils에도 getCookies를 테스트할 때 목 써서 
`when(request.getCookies()).thenReturn(cookies);`
이런식으로 성공시켰었습니다.

이런식으로 테스트해도 괜찮은게 맞을까요..? 
궁금한 부분에 댓글을 따로 달았는데,
시간 되실때 한 번 봐주시면 감사하겠습니다! ㅜ
